### PR TITLE
Fix inclusion of raytri.c and C++17 compilation on MSVC

### DIFF
--- a/cmake/libigl.cmake
+++ b/cmake/libigl.cmake
@@ -77,6 +77,10 @@ target_compile_features(igl_common INTERFACE ${CXX11_FEATURES})
 if(MSVC)
   # Enable parallel compilation for Visual Studio
   target_compile_options(igl_common INTERFACE /MP /bigobj)
+  target_compile_options(igl_common INTERFACE /Zc:__cplusplus)
+  if(LIBIGL_USE_STATIC_LIBRARY)
+    target_compile_definitions(igl_common INTERFACE -D_USE_MATH_DEFINES)
+  endif()
   if(LIBIGL_WITH_CGAL)
     target_compile_options(igl_common INTERFACE "/MD$<$<CONFIG:Debug>:d>")
   endif()
@@ -449,7 +453,7 @@ function(install_dir_files dir_name)
 
   if(NOT LIBIGL_USE_STATIC_LIBRARY)
     file(GLOB public_sources
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/igl${subpath}/*.c*
     )
   endif()
   list(APPEND files_to_install ${public_sources})

--- a/include/igl/randperm.cpp
+++ b/include/igl/randperm.cpp
@@ -8,6 +8,9 @@
 #include "randperm.h"
 #include "colon.h"
 #include <algorithm> 
+#if(__cplusplus >= 201402L)
+#  include <random>
+#endif
 
 template <typename DerivedI>
 IGL_INLINE void igl::randperm(
@@ -17,7 +20,13 @@ IGL_INLINE void igl::randperm(
   Eigen::VectorXi II;
   igl::colon(0,1,n-1,II);
   I = II;
+#if(__cplusplus >= 201402L)
+  std::random_device rng;
+  std::mt19937 urng(rng());
+  std::shuffle(I.data(),I.data()+n,urng);
+#else
   std::random_shuffle(I.data(),I.data()+n);
+#endif
 }
 
 #ifdef IGL_STATIC_LIBRARY


### PR DESCRIPTION
@ruslo, addressed the issue from the previous version, which misses installing raytri.c (a problem from upstream). Also fixed compilation issues for MSVC with C++17.